### PR TITLE
Bug#1634932/83648: Assertion failure in thread x in file fts0que.cc

### DIFF
--- a/mysql-test/suite/innodb_fts/r/bug83648.result
+++ b/mysql-test/suite/innodb_fts/r/bug83648.result
@@ -1,0 +1,37 @@
+#
+# Bug 1634932: Assertion failure in thread x in
+# file fts0que.cc
+#
+SET @saved_innodb_ft_result_cache_limit= @@global.innodb_ft_result_cache_limit;
+CREATE TABLE `t1` (
+`FTS_DOC_ID` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+`text_content` MEDIUMTEXT, PRIMARY KEY (`FTS_DOC_ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+CREATE UNIQUE INDEX FTS_DOC_ID_INDEX ON t1(FTS_DOC_ID);
+SET autocommit=0;
+CREATE PROCEDURE populate_t1()
+BEGIN
+DECLARE i INT DEFAULT 1;
+WHILE (i <= 250) DO
+INSERT INTO t1 (text_content) VALUES ("some_text_1234 aaa");
+SET i = i + 1;
+END WHILE;
+END//
+CALL populate_t1;
+SET autocommit=1;
+SET SESSION debug="+d,fts_instrument_result_cache_limit";
+ALTER TABLE t1 ADD FULLTEXT INDEX `text_content_idx` (`text_content`);
+SELECT FTS_DOC_ID, text_content
+FROM t1
+WHERE MATCH text_content AGAINST ('+some_text_1234' IN BOOLEAN MODE);
+ERROR HY000: FTS query exceeds result cache limit
+UPDATE t1
+SET text_content='some_text_12345'
+where MATCH text_content AGAINST ('+some_text_1234' IN BOOLEAN MODE);
+ERROR HY000: FTS query exceeds result cache limit
+DELETE FROM t1
+WHERE MATCH text_content AGAINST ('+some_text_1234' IN BOOLEAN MODE);
+ERROR HY000: FTS query exceeds result cache limit
+SET GLOBAL innodb_ft_result_cache_limit = @saved_innodb_ft_result_cache_limit;
+DROP TABLE t1;
+DROP PROCEDURE populate_t1;

--- a/mysql-test/suite/innodb_fts/t/bug83648.test
+++ b/mysql-test/suite/innodb_fts/t/bug83648.test
@@ -1,0 +1,57 @@
+--echo #
+--echo # Bug 1634932: Assertion failure in thread x in
+--echo # file fts0que.cc
+--echo #
+
+--source include/have_innodb.inc
+--source include/have_debug.inc
+
+SET @saved_innodb_ft_result_cache_limit= @@global.innodb_ft_result_cache_limit;
+
+CREATE TABLE `t1` (
+	`FTS_DOC_ID` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+	`text_content` MEDIUMTEXT, PRIMARY KEY (`FTS_DOC_ID`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
+
+CREATE UNIQUE INDEX FTS_DOC_ID_INDEX ON t1(FTS_DOC_ID);
+
+SET autocommit=0;
+
+DELIMITER //;
+CREATE PROCEDURE populate_t1()
+BEGIN
+        DECLARE i INT DEFAULT 1;
+        WHILE (i <= 250) DO
+          INSERT INTO t1 (text_content) VALUES ("some_text_1234 aaa");
+          SET i = i + 1;
+        END WHILE;
+END//
+
+DELIMITER ;//
+
+CALL populate_t1;
+SET autocommit=1;
+
+SET SESSION debug="+d,fts_instrument_result_cache_limit";
+
+ALTER TABLE t1 ADD FULLTEXT INDEX `text_content_idx` (`text_content`);
+
+# HA_ERR_FTS_EXCEED_RESULT_CACHE_LIMIT = 188
+--error 188
+SELECT FTS_DOC_ID, text_content
+FROM t1
+WHERE MATCH text_content AGAINST ('+some_text_1234' IN BOOLEAN MODE);
+
+--error 188
+UPDATE t1
+SET text_content='some_text_12345'
+where MATCH text_content AGAINST ('+some_text_1234' IN BOOLEAN MODE);
+
+--error 188
+DELETE FROM t1
+WHERE MATCH text_content AGAINST ('+some_text_1234' IN BOOLEAN MODE);
+
+SET GLOBAL innodb_ft_result_cache_limit = @saved_innodb_ft_result_cache_limit;
+
+DROP TABLE t1;
+DROP PROCEDURE populate_t1;

--- a/sql/sql_delete.cc
+++ b/sql/sql_delete.cc
@@ -411,6 +411,9 @@ bool Sql_cmd_delete::mysql_delete(THD *thd, ha_rows limit)
       goto exit_without_my_ok;
     }
 
+    if (select_lex->has_ft_funcs() && init_ftfuncs(thd, select_lex))
+      goto exit_without_my_ok;
+
     if (usable_index==MAX_KEY || qep_tab.quick())
       error= init_read_record(&info, thd, NULL, &qep_tab, 1, 1, FALSE);
     else
@@ -421,9 +424,6 @@ bool Sql_cmd_delete::mysql_delete(THD *thd, ha_rows limit)
       err= true; /* purecov: inspected */
       goto exit_without_my_ok;
     }
-
-    if (select_lex->has_ft_funcs() && init_ftfuncs(thd, select_lex))
-      goto exit_without_my_ok;
 
     THD_STAGE_INFO(thd, stage_updating);
 

--- a/storage/innobase/fts/fts0que.cc
+++ b/storage/innobase/fts/fts0que.cc
@@ -941,6 +941,18 @@ fts_query_free_doc_ids(
 	query->total_size -= SIZEOF_RBT_CREATE;
 }
 
+/**
+Free the query intersection
+@param[in] query	query instance */
+static
+void
+fts_query_free_intersection(
+	fts_query_t*	query)
+{
+	fts_query_free_doc_ids(query, query->intersection);
+	query->intersection = NULL;
+}
+
 /*******************************************************************//**
 Add the word to the documents "list" of matching words from
 the query. We make a copy of the word from the query heap. */
@@ -1307,6 +1319,7 @@ fts_query_intersect(
 		/* error is passed by 'query->error' */
 		if (query->error != DB_SUCCESS) {
 			ut_ad(query->error == DB_FTS_EXCEED_RESULT_CACHE_LIMIT);
+			fts_query_free_intersection(query);
 			return(query->error);
 		}
 
@@ -1335,6 +1348,8 @@ fts_query_intersect(
 
 			ut_a(!query->multi_exist || (query->multi_exist
 			     && rbt_size(query->doc_ids) <= n_doc_ids));
+		} else if (query->intersection != NULL) {
+			fts_query_free_intersection(query);
 		}
 	}
 
@@ -1553,6 +1568,11 @@ fts_merge_doc_ids(
 				query, ranking->doc_id, ranking->rank);
 
 		if (query->error != DB_SUCCESS) {
+			if (query->intersection != NULL)
+			{
+				ut_a(query->oper == FTS_EXIST);
+				fts_query_free_intersection(query);
+			}
 			DBUG_RETURN(query->error);
 		}
 


### PR DESCRIPTION
The bug was caused by three problems:
1) query->intersection was not freed in case of error caused by
exceeding innodb_ft_result_cache_limit.
2) errors from init_ftfuncs were not propagated - this was fixed
in 5.7 by bug fix 21140111. This was ported into 5.6
3) bug fix 21140111 was causing assertion failure when
innodb_ft_result_cache was exceeded in DELETE command. This was
also fixed.