### PR TITLE
Bug#1688319: Test binlog.binlog_gtid_state_update_deadlock is

### DIFF
--- a/mysql-test/suite/binlog_nogtid/r/binlog_gtid_state_update_deadlock.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_gtid_state_update_deadlock.result
@@ -5,7 +5,7 @@ SET @@SESSION.DEBUG_SYNC = 'update_gtid_state_after_global_sid_lock SIGNAL have_
 SET @@SESSION.GTID_NEXT= 'ANONYMOUS';
 INSERT INTO t1 VALUES (1);
 SET @@SESSION.DEBUG_SYNC = 'now WAIT_FOR before_global_sid_lock';
-SET @@SESSION.DEBUG_SYNC= 'after_log_file_name_initialized SIGNAL have_gtid_mode_lock WAIT_FOR have_global_sid_lock';
+SET @@SESSION.DEBUG_SYNC= 'gtid_mode_update_gtid_mode_lock_wrlock_taken_will_take_global_sid_lock SIGNAL have_gtid_mode_lock WAIT_FOR have_global_sid_lock';
 SET @@GLOBAL.GTID_MODE = OFF_PERMISSIVE;
 SET @@GLOBAL.GTID_MODE = OFF;
 DROP TABLE t1;

--- a/mysql-test/suite/binlog_nogtid/t/binlog_gtid_state_update_deadlock.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_gtid_state_update_deadlock.test
@@ -31,7 +31,6 @@
 # 6. server_1_1 continues; it holds gtid_mode_lock and tries to acquire
 #    global_sid_lock.
 
---source include/big_test.inc
 --source include/have_debug_sync.inc
 # One binlog_format is enough.
 --source include/have_binlog_format_statement.inc
@@ -57,7 +56,7 @@ SET @@SESSION.DEBUG_SYNC = 'now WAIT_FOR before_global_sid_lock';
 --connection server_1_1
 #  3. wait when holding gtid_mode_lock, before takeing global_sid_lock.
 #  6. once the INSERT has taken global_sid_lock, unpause and hit the deadlock
-SET @@SESSION.DEBUG_SYNC= 'after_log_file_name_initialized SIGNAL have_gtid_mode_lock WAIT_FOR have_global_sid_lock';
+SET @@SESSION.DEBUG_SYNC= 'gtid_mode_update_gtid_mode_lock_wrlock_taken_will_take_global_sid_lock SIGNAL have_gtid_mode_lock WAIT_FOR have_global_sid_lock';
 SET @@GLOBAL.GTID_MODE = OFF_PERMISSIVE;
 
 --connection server_1

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -4885,8 +4885,6 @@ bool MYSQL_BIN_LOG::open_binlog(const char *log_name,
 
   DBUG_PRINT("info", ("generated filename: %s", log_file_name));
 
-  DEBUG_SYNC(current_thd, "after_log_file_name_initialized");
-
   if (open_purge_index_file(TRUE) ||
       register_create_index_entry(log_file_name) ||
       sync_purge_index_file() ||

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -3808,7 +3808,7 @@ bool Sys_var_gtid_set::session_update(THD *thd, set_var *var)
 #endif // HAVE_GTID_NEXT_LIST
 
 
-bool Sys_var_gtid_mode::global_update(THD*, set_var *var)
+bool Sys_var_gtid_mode::global_update(THD* thd, set_var *var)
 {
   DBUG_ENTER("Sys_var_gtid_mode::global_update");
   bool ret= true;
@@ -3835,6 +3835,7 @@ bool Sys_var_gtid_mode::global_update(THD*, set_var *var)
     to take the other locks.
   */
   gtid_mode_lock->wrlock();
+  DEBUG_SYNC(thd, "gtid_mode_update_gtid_mode_lock_wrlock_taken_will_take_global_sid_lock");
   channel_map.wrlock();
   mysql_mutex_lock(mysql_bin_log.get_log_lock());
   global_sid_lock->wrlock();


### PR DESCRIPTION
failing on 5.7 trunk

According to this test sync point after_log_file_name_initialized
should be initialized on changing GLOBAL.GTID_MODE. However, debug sync
after_log_file_name_initialized  was never hit on changing GTID_MODE.
The purpose of this debug sync point was to hold execution after
gtid_mode_lock was acquired, but before global_sid_lock was locked.
The fix was to add new debug sync
gtid_mode_update_gtid_mode_lock_wrlock_taken_will_take_global_sid_lock
which fulfills this requirements. Without the fix the test just
timeout on debug sync point after_log_file_name_initialized – that is why
–include/big_test.inc was added to this test by upstream, which now
have been removed.