### PR TITLE
Bug#1689548: Test rpl.bug84415 is unstable

### DIFF
--- a/mysql-test/suite/rpl/t/bug84415.test
+++ b/mysql-test/suite/rpl/t/bug84415.test
@@ -106,11 +106,10 @@ UNLOCK TABLES;
 # Now both workers have completed their tasks and no new tasks have arrived, thus
 # Seconds_Behind_Master should be equal to 0.
 
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
-source include/wait_for_mts_checkpoint.inc;
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Executing event'
-                                                                             OR State = 'update';
+let $wait_condition= SELECT count(*) = 4 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for an event from Coordinator';
 --source include/wait_condition.inc
+
+source include/wait_for_mts_checkpoint.inc;
 
 let $sbm= query_get_value("SHOW SLAVE STATUS", Seconds_Behind_Master, 1);
 let $assert_text= Seconds_Behind_Master must be 0;
@@ -163,14 +162,8 @@ source include/assert.inc;
 connection slave2;
 UNLOCK TABLES;
 
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
+let $wait_condition= SELECT count(*) = 4 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for an event from Coordinator';
 --source include/wait_condition.inc
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Executing event'
-                                                                             OR State = 'update';
---source include/wait_condition.inc
-
-# Now both workers have completed their tasks and no new tasks have arrived, thus
-# Seconds_Behind_Master should be equal to 0.
 
 source include/wait_for_mts_checkpoint.inc;
 
@@ -257,14 +250,10 @@ source include/assert.inc;
 connection slave3;
 UNLOCK TABLES;
 
-# Now all three workers have completed. Seconds_Behind_Master should be 0.
+# Now all four workers have completed. Seconds_Behind_Master should be 0.
 
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
+let $wait_condition= SELECT count(*) = 4 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for an event from Coordinator';
 --source include/wait_condition.inc
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Executing event'
-                                                                             OR State = 'update';
---source include/wait_condition.inc
-
 
 source include/wait_for_mts_checkpoint.inc;
 

--- a/mysql-test/suite/rpl/t/bug84415_logical_clock.test
+++ b/mysql-test/suite/rpl/t/bug84415_logical_clock.test
@@ -87,10 +87,7 @@ UNLOCK TABLES;
 connection master;
 --source include/sync_slave_sql_with_master.inc
 
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
---source include/wait_condition.inc
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Executing event'
-                                                                             OR State = 'update';
+let $wait_condition= SELECT count(*) = 3 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for an event from Coordinator';
 --source include/wait_condition.inc
 
 source include/wait_for_mts_checkpoint.inc;
@@ -170,10 +167,7 @@ UNLOCK TABLES;
 --source include/sync_slave_sql_with_master.inc
 
 # All workers should be done by now.
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
---source include/wait_condition.inc
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Executing event'
-                                                                             OR State = 'update';
+let $wait_condition= SELECT count(*) = 3 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for an event from Coordinator';
 --source include/wait_condition.inc
 
 source include/wait_for_mts_checkpoint.inc;
@@ -319,10 +313,7 @@ connection slave2;
 UNLOCK TABLE;
 
 # Wait for all workers to be done
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for table metadata lock';
---source include/wait_condition.inc
-let $wait_condition= SELECT count(*) = 0 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Executing event'
-                                                                             OR State = 'update';
+let $wait_condition= SELECT count(*) = 3 FROM INFORMATION_SCHEMA.PROCESSLIST WHERE State = 'Waiting for an event from Coordinator';
 --source include/wait_condition.inc
 
 # All catched up Seconds_Behind_Master should be 0. Lets wait some more to see if it does not increase


### PR DESCRIPTION
Bug fix:
- Changed the condition before checking if SBM == 0. Now the check is
  done when all slave workers are waiting for events from Coordinator.
- Added missing include/wait_for_mts_checkpoint.inc before checking
  if Seconds_Behind_Master is equal 0.