### PR TITLE
lp-1733049: Blackhole : Specified key was too long; max key length is…

### DIFF
--- a/mysql-test/r/bug53588.result
+++ b/mysql-test/r/bug53588.result
@@ -1,0 +1,5 @@
+CREATE TABLE `t` (
+`a` varchar(750) NOT NULL default '',
+PRIMARY KEY  (`a`)
+) ENGINE=BLACKHOLE;
+DROP TABLE `t`;

--- a/mysql-test/t/bug53588.test
+++ b/mysql-test/t/bug53588.test
@@ -1,0 +1,23 @@
+#
+# Bug 53588 test case.
+#
+# Create long enough index (between 1000 and 3500). 1000 is the old value,
+# 3500 is innodb value (see ha_innobase::max_supported_key_length()). Without
+# the fix the test will fail with "Specified key was too long" error.
+#
+# For 8.0 the actual key length is counted as a value from statement,
+# multiplied by the maximum symbol lenght of the key's charset.
+#
+--source include/have_blackhole.inc
+
+# As default test charset is UTF-8 with 4-byte maximum symbol length, the `a`
+# key length will be multiplied by 4 (750*4 = 3000) and compared with what
+# blackhole storage engine returns from
+# ha_blackhole::max_supported_key_length(), that is why we need to reduce
+# the initial key length (3000) by 4 times to pass the test.
+CREATE TABLE `t` (
+  `a` varchar(750) NOT NULL default '',
+  PRIMARY KEY  (`a`)
+) ENGINE=BLACKHOLE;
+
+DROP TABLE `t`;

--- a/storage/blackhole/ha_blackhole.h
+++ b/storage/blackhole/ha_blackhole.h
@@ -19,6 +19,7 @@
 #include "my_inttypes.h"
 #include "table.h"                              /* TABLE_SHARE */
 #include "thr_lock.h"                           /* THR_LOCK */
+#include "sql_const.h"                          /* MAX_KEY */
 
 /*
   Shared structure for correct LOCK operation
@@ -65,9 +66,9 @@ public:
             HA_READ_ORDER | HA_KEYREAD_ONLY);
   }
   /* The following defines can be increased if necessary */
-#define BLACKHOLE_MAX_KEY	64		/* Max allowed keys */
+#define BLACKHOLE_MAX_KEY	MAX_KEY		/* Max allowed keys */
 #define BLACKHOLE_MAX_KEY_SEG	16		/* Max segments for key */
-#define BLACKHOLE_MAX_KEY_LENGTH 1000
+#define BLACKHOLE_MAX_KEY_LENGTH	3500		/* Like in InnoDB */
   uint max_supported_keys()          const { return BLACKHOLE_MAX_KEY; }
   uint max_supported_key_length()    const { return BLACKHOLE_MAX_KEY_LENGTH; }
   uint max_supported_key_part_length() const { return BLACKHOLE_MAX_KEY_LENGTH; }


### PR DESCRIPTION
… 1000 bytes

The maximum innodb key length is 3500 what is hardcoded in
ha_innobase::max_supported_key_length()). The maximum number of innodb indexes
is configured with MAX_INDEXES macro (see also MAX_KEY definition).

The same is currently implemented for blackhole storage engine.

There is difference between 8.0 and earlier versions. 8.0 counts the actual key
length as a multiplication of key length given from statement and the maximum
symbol lenght of table's charset
(see Create_field::create_length_to_internal_length()).

That's why the key length in the test is divided by 4(the maximum symbol length
in UTF-8).

(cherry picked from commit 0d90d81c3c507a6b1476246a405504f6e4ef9d4d)

https://jenkins.percona.com/view/5.7/job/mysql-5.7-param/1467/