### PR TITLE
PS-311: On server shutdown threadpool is crashing in debug mode due

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -5467,6 +5467,8 @@ int mysqld_main(int argc, char **argv)
   ulong requested_open_files;
   init_error_log();
   adjust_related_options(&requested_open_files);
+  // moved signal initialization here so that PFS thread inherited signal mask
+  my_init_signals();
 
 #ifdef WITH_PERFSCHEMA_STORAGE_ENGINE
   if (ho_error == 0)
@@ -5743,8 +5745,6 @@ int mysqld_main(int argc, char **argv)
 
   if (init_common_variables())
     unireg_abort(MYSQLD_ABORT_EXIT);        // Will do exit
-
-  my_init_signals();
 
   size_t guardize= 0;
 #ifndef _WIN32


### PR DESCRIPTION
to race condition

This patch was ported from 5.7. The original commit message from 5.7
reads:
"Moved calling set_my_sys_thread_var before signaling conditional
 variable THR_COND_threads. This is variable on which my_thread_global_end is
 waiting. After it is signalled THR_KEY_mysys_initialized is set to FALSE in
 my_thread_global_end. There is a debug assertion that THE_KEY_mysys_initialized == TRUE in
 set_my_sys_thread_var.

 Moved my_init_signals, which sets signal mask to block all
 handleable kill signals - which are later serviced by signal_hand thread. my_init_singals
 was moved before PFS initialization. PFS thread can be affected by
 "handleable kill" signals unless they have singal mask set.

Only second part of this patch is ported from 5.7.
The first part is no longer valid as the debug assertion
THE_KEY_mysys_initialized == TRUE was removed.