### PR TITLE
PS-3925: Use strncmp instead of memcmp in log_in_use

### DIFF
--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -2996,7 +2996,7 @@ public:
     mysql_mutex_lock(&thd->LOCK_thd_data);
     if ((linfo = thd->current_linfo))
     {
-      if(!memcmp(m_log_name, linfo->log_file_name, m_log_name_len))
+      if(!strncmp(m_log_name, linfo->log_file_name, m_log_name_len))
       {
         LogErr(WARNING_LEVEL, ER_BINLOG_FILE_BEING_READ_NOT_PURGED,
                m_log_name, thd->thread_id());


### PR DESCRIPTION
(cherry picked from commit 2c950c3ca2bf890549825417c10dd3065b78befc)
(cherry picked from commit 2fb17005e0d4b5d3c3c53d817e2be1c899a94e59)
(cherry picked from commit 96f907bb235455521a11992675cdf12c9508d822)